### PR TITLE
Fix memory leaks

### DIFF
--- a/spidev_module.c
+++ b/spidev_module.c
@@ -235,6 +235,9 @@ SpiDev_xfer(SpiDevObject *self, PyObject *args)
 		PyObject *val = PyList_GET_ITEM(list, ii);
 		if (!PyInt_Check(val)) {
 			PyErr_SetString(PyExc_TypeError, wrmsg);
+			free(xferptr);
+			free(txbuf);
+			free(rxbuf);
 			return NULL;
 		}
 		txbuf[ii] = (__u8)PyInt_AS_LONG(val);
@@ -249,6 +252,9 @@ SpiDev_xfer(SpiDevObject *self, PyObject *args)
 	status = ioctl(self->fd, SPI_IOC_MESSAGE(len), xferptr);
 	if (status < 0) {
 		PyErr_SetFromErrno(PyExc_IOError);
+		free(xferptr);
+		free(txbuf);
+		free(rxbuf);
 		return NULL;
 	}
 #else
@@ -256,6 +262,8 @@ SpiDev_xfer(SpiDevObject *self, PyObject *args)
 		PyObject *val = PyList_GET_ITEM(list, ii);
 		if (!PyInt_Check(val)) {
 			PyErr_SetString(PyExc_TypeError, wrmsg);
+			free(txbuf);
+			free(rxbuf);
 			return NULL;
 		}
 		txbuf[ii] = (__u8)PyInt_AS_LONG(val);
@@ -271,10 +279,13 @@ SpiDev_xfer(SpiDevObject *self, PyObject *args)
 	status = ioctl(self->fd, SPI_IOC_MESSAGE(1), &xfer);
 	if (status < 0) {
 		PyErr_SetFromErrno(PyExc_IOError);
+		free(txbuf);
+		free(rxbuf);
 		return NULL;
 	}
 #endif
 
+	list = PyList_New(len);
 	for (ii = 0; ii < len; ii++) {
 		PyObject *val = Py_BuildValue("l", (long)rxbuf[ii]);
 		PyList_SET_ITEM(list, ii, val);
@@ -290,7 +301,6 @@ SpiDev_xfer(SpiDevObject *self, PyObject *args)
 	free(txbuf);
 	free(rxbuf);
 
-	Py_INCREF(list);
 	return list;
 }
 
@@ -334,6 +344,8 @@ SpiDev_xfer2(SpiDevObject *self, PyObject *args)
 		PyObject *val = PyList_GET_ITEM(list, ii);
 		if (!PyInt_Check(val)) {
 			PyErr_SetString(PyExc_TypeError, msg);
+			free(txbuf);
+			free(rxbuf);
 			return NULL;
 		}
 		txbuf[ii] = (__u8)PyInt_AS_LONG(val);
@@ -349,9 +361,12 @@ SpiDev_xfer2(SpiDevObject *self, PyObject *args)
 	status = ioctl(self->fd, SPI_IOC_MESSAGE(1), &xfer);
 	if (status < 0) {
 		PyErr_SetFromErrno(PyExc_IOError);
+		free(txbuf);
+		free(rxbuf);
 		return NULL;
 	}
 
+	list = PyList_New(len);
 	for (ii = 0; ii < len; ii++) {
 		PyObject *val = Py_BuildValue("l", (long)rxbuf[ii]);
 		PyList_SET_ITEM(list, ii, val);
@@ -366,7 +381,6 @@ SpiDev_xfer2(SpiDevObject *self, PyObject *args)
 	free(txbuf);
 	free(rxbuf);
 
-	Py_INCREF(list);
 	return list;
 }
 


### PR DESCRIPTION
Fix two memory leaks in the xfer/xfer2 functions.
If an error occurs we need to free up the transfer buffers.
We are modifying and returning the list we are passed.  This is against normal Python policy: functions should either return a new value, or modify an argument in place (not return a modified argument). A related issue is that PyList_SET_ITEM does not dereference the object that was in the list, so we are potentially leaking all the items passed in.
These are fixed by allocating and populating a new list object.