### PR TITLE
Adapt to updated spidev kernel 3.15+ API

### DIFF
--- a/spidev_module.c
+++ b/spidev_module.c
@@ -251,6 +251,12 @@ SpiDev_xfer(SpiDevObject *self, PyObject *args)
 		xferptr[ii].delay_usecs = delay;
 		xferptr[ii].speed_hz = speed_hz ? speed_hz : self->max_speed_hz;
 		xferptr[ii].bits_per_word = bits_per_word ? bits_per_word : self->bits_per_word;
+#ifdef SPI_IOC_WR_MODE32
+		xferptr[ii].tx_nbits = 0;
+#endif
+#ifdef SPI_IOC_RD_MODE32
+		xferptr[ii].rx_nbits = 0;
+#endif
 	}
 
 	status = ioctl(self->fd, SPI_IOC_MESSAGE(len), xferptr);
@@ -274,6 +280,12 @@ SpiDev_xfer(SpiDevObject *self, PyObject *args)
 	xfer.delay_usecs = delay_usecs;
 	xfer.speed_hz = speed_hz ? speed_hz : self->max_speed_hz;
 	xfer.bits_per_word = bits_per_word ? bits_per_word : self->bits_per_word;
+#ifdef SPI_IOC_WR_MODE32
+        xfer.tx_nbits = 0;
+#endif
+#ifdef SPI_IOC_RD_MODE32
+        xfer.rx_nbits = 0;
+#endif
 
 	status = ioctl(self->fd, SPI_IOC_MESSAGE(1), &xfer);
 	if (status < 0) {


### PR DESCRIPTION
New fields in spi_ioc_transfer struct: tx_nbits, rx_nbits
New IOCTLs: SPI_IOC_WR_MODE32, SPI_IOC_RD_MODE32 - we are checking for these to determine if the new fields are available in spi_ioc_transfer
see also https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit?id=dc64d39b54c1e9db97a6fb1ca52598c981728157