### PR TITLE
Fix bug preventing setting the `mode` attribute

### DIFF
--- a/spidev_module.c
+++ b/spidev_module.c
@@ -507,13 +507,15 @@ SpiDev_set_mode(SpiDevObject *self, PyObject *val, void *closure)
 			"Cannot delete attribute");
 		return -1;
 	}
-	else if (!PyLong_Check(val)) {
+	else if (PyLong_Check(val)) {
+		mode = PyLong_AsLong(val);
+	} else if (PyInt_Check(val)) {
+		mode = PyInt_AsLong(val);
+	} else {
 		PyErr_SetString(PyExc_TypeError,
 			"The mode attribute must be an integer");
 		return -1;
 	}
-
-	mode = PyLong_AsLong(val);
 
 	if ( mode > 3 ) {
 		PyErr_SetString(PyExc_TypeError,


### PR DESCRIPTION
This fixes the bug reported in
http://stackoverflow.com/questions/31227767/python-spidev-typeerror/31231301

Without this fix:

    >>> import spidev
    >>> s = spidev.SpiDev()
    >>> s.open(0,0)
    >>> s.mode = 1
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    TypeError: The mode attribute must be an integer

