### PR TITLE
Add example to 'Settings' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,25 @@ spi.xfer(to_send)
 Settings
 --------
 
-* bits_per_word
-* cshigh
-* loop
-* lsbfirst
-* max_speed_hz
-* mode - SPI mode as two bit pattern of clock polarity and phase [CPOL|CPHA], min: 0b00 = 0, max: 0b11 = 3
-* threewire - SI/SO signals shared
+```python
+import spidev
+spi = spidev.SpiDev()
+spi.open(bus, device)
+
+# Settings (for example)
+spi.max_speed_hz = 5000
+spi.mode = 0b01
+
+...
+```
+
+* `bits_per_word`
+* `cshigh`
+* `loop`
+* `lsbfirst`
+* `max_speed_hz`
+* `mode` - SPI mode as two bit pattern of clock polarity and phase [CPOL|CPHA], min: 0b00 = 0, max: 0b11 = 3
+* `threewire` - SI/SO signals shared
 
 Methods
 -------


### PR DESCRIPTION
Adds a code example to the Settings section and puts each setting into a code tag. This may be obvious to those more experienced, but it took me a while to figure out how to change these settings. Hopefully this can help somebody like me in the future!

Any improvements on my example are welcome, of course.