### PR TITLE
Fix build with musl libc

### DIFF
--- a/spidev_module.c
+++ b/spidev_module.c
@@ -25,6 +25,7 @@
 #include <linux/spi/spidev.h>
 #include <linux/types.h>
 #include <sys/ioctl.h>
+#include <linux/ioctl.h>
 
 #define SPIDEV_MAXPATH 4096
 


### PR DESCRIPTION
Include missing header to prevent build error:

spidev_module.c: In function ‘SpiDev_xfer’:
spidev_module.c:330:27: error: ‘_IOC_SIZEBITS’ undeclared (first use in this function)
  status = ioctl(self->fd, SPI_IOC_MESSAGE(1), &xfer);
                           ^
spidev_module.c:330:27: note: each undeclared identifier is reported only once for each function it appears in
spidev_module.c: In function ‘SpiDev_xfer2’:
spidev_module.c:421:27: error: ‘_IOC_SIZEBITS’ undeclared (first use in this function)
  status = ioctl(self->fd, SPI_IOC_MESSAGE(1), &xfer);
                           ^

Signed-off-by: Bernd Kuhls bernd.kuhls@t-online.de