### PR TITLE
Add support for "SPI_NO_CS" flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ spi.mode = 0b01
 * `bits_per_word`
 * `cshigh`
 * `loop`
+* `no_cs` - Set the "SPI_NO_CS" flag to disable use of the chip select (although the driver may still own the CS pin)
 * `lsbfirst`
 * `max_speed_hz`
 * `mode` - SPI mode as two bit pattern of clock polarity and phase [CPOL|CPHA], min: 0b00 = 0, max: 0b11 = 3

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ spi.mode = 0b01
 
 * `bits_per_word`
 * `cshigh`
-* `loop`
+* `loop` - Set the "SPI_LOOP" flag to enable loopback mode
 * `no_cs` - Set the "SPI_NO_CS" flag to disable use of the chip select (although the driver may still own the CS pin)
 * `lsbfirst`
 * `max_speed_hz`

--- a/spidev_module.c
+++ b/spidev_module.c
@@ -29,6 +29,7 @@
 
 #define SPIDEV_MAXPATH 4096
 
+#define SPIDEV_MODE_FLAGS (SPI_CPHA | SPI_LOOP | SPI_CPOL | SPI_NO_CS)
 
 #if PY_MAJOR_VERSION < 3
 #define PyLong_AS_LONG(val) PyInt_AS_LONG(val)
@@ -517,7 +518,7 @@ SpiDev_fileno(SpiDevObject *self)
 static PyObject *
 SpiDev_get_mode(SpiDevObject *self, void *closure)
 {
-	PyObject *result = Py_BuildValue("i", (self->mode & (SPI_CPHA | SPI_CPOL) ) );
+	PyObject *result = Py_BuildValue("i", (self->mode & SPIDEV_MODE_FLAGS ) );
 	Py_INCREF(result);
 	return result;
 }
@@ -612,8 +613,8 @@ SpiDev_set_mode(SpiDevObject *self, PyObject *val, void *closure)
 		return -1;
 	}
 
-	// clean and set CPHA and CPOL bits
-	tmp = ( self->mode & ~(SPI_CPHA | SPI_CPOL) ) | mode ;
+	// clean and set mode bits
+	tmp = ( self->mode & ~SPIDEV_MODE_FLAGS ) | mode ;
 
 	__spidev_set_mode(self->fd, tmp);
 

--- a/spidev_module.c
+++ b/spidev_module.c
@@ -29,7 +29,6 @@
 
 #define SPIDEV_MAXPATH 4096
 
-#define SPIDEV_MODE_FLAGS (SPI_CPHA | SPI_LOOP | SPI_CPOL | SPI_NO_CS)
 
 #if PY_MAJOR_VERSION < 3
 #define PyLong_AS_LONG(val) PyInt_AS_LONG(val)
@@ -518,7 +517,7 @@ SpiDev_fileno(SpiDevObject *self)
 static PyObject *
 SpiDev_get_mode(SpiDevObject *self, void *closure)
 {
-	PyObject *result = Py_BuildValue("i", (self->mode & SPIDEV_MODE_FLAGS ) );
+	PyObject *result = Py_BuildValue("i", (self->mode & (SPI_CPHA | SPI_CPOL) ) );
 	Py_INCREF(result);
 	return result;
 }
@@ -579,6 +578,20 @@ SpiDev_get_loop(SpiDevObject *self, void *closure)
 	return result;
 }
 
+static PyObject *
+SpiDev_get_no_cs(SpiDevObject *self, void *closure)
+{
+        PyObject *result;
+
+        if (self->mode & SPI_NO_CS)
+                result = Py_True;
+        else
+                result = Py_False;
+
+        Py_INCREF(result);
+        return result;
+}
+
 
 static int
 SpiDev_set_mode(SpiDevObject *self, PyObject *val, void *closure)
@@ -613,8 +626,8 @@ SpiDev_set_mode(SpiDevObject *self, PyObject *val, void *closure)
 		return -1;
 	}
 
-	// clean and set mode bits
-	tmp = ( self->mode & ~SPIDEV_MODE_FLAGS ) | mode ;
+	// clean and set CPHA and CPOL bits
+	tmp = ( self->mode & ~(SPI_CPHA | SPI_CPOL) ) | mode ;
 
 	__spidev_set_mode(self->fd, tmp);
 
@@ -702,6 +715,34 @@ SpiDev_set_3wire(SpiDevObject *self, PyObject *val, void *closure)
 	self->mode = tmp;
 	return 0;
 }
+
+static int
+SpiDev_set_no_cs(SpiDevObject *self, PyObject *val, void *closure)
+{
+        uint8_t tmp;
+
+        if (val == NULL) {
+                PyErr_SetString(PyExc_TypeError,
+                        "Cannot delete attribute");
+                return -1;
+        }
+        else if (!PyBool_Check(val)) {
+                PyErr_SetString(PyExc_TypeError,
+                        "The no_cs attribute must be boolean");
+                return -1;
+        }
+
+        if (val == Py_True)
+                tmp = self->mode | SPI_NO_CS;
+        else
+                tmp = self->mode & ~SPI_NO_CS;
+
+        __spidev_set_mode(self->fd, tmp);
+
+        self->mode = tmp;
+        return 0;
+}
+
 
 static int
 SpiDev_set_loop(SpiDevObject *self, PyObject *val, void *closure)
@@ -835,6 +876,8 @@ static PyGetSetDef SpiDev_getset[] = {
 			"LSB first\n"},
 	{"loop", (getter)SpiDev_get_loop, (setter)SpiDev_set_loop,
 			"loopback configuration\n"},
+	{"no_cs", (getter)SpiDev_get_no_cs, (setter)SpiDev_set_no_cs,
+			"disable chip select\n"},
 	{"bits_per_word", (getter)SpiDev_get_bits_per_word, (setter)SpiDev_set_bits_per_word,
 			"bits per word\n"},
 	{"max_speed_hz", (getter)SpiDev_get_max_speed_hz, (setter)SpiDev_set_max_speed_hz,


### PR DESCRIPTION
Allows the user to disable the SPI chip select by setting the driver's SPI_NO_CS flag.  