### PR TITLE
Added __version__ attribute to module for #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Methods
 
     open(bus, device)
 
-Connects to the specified SPI device, opening /dev/spidev-bus.device
+Connects to the specified SPI device, opening `/dev/spidev<bus>.<device>`
 
     readbytes(n)
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,16 @@
 
 from distutils.core import setup, Extension
 
+version = "0.0"
+
+lines = [x for x in open("spidev_module.c").read().split("\n") if "#define" in x and "_VERSION_" in x and "\"" in x]
+
+if len(lines) > 0:
+    version = lines[0].split("\"")[1]
+else:
+    raise Exception("Unable to find _VERSION_ in spidev_module.c")
+
+
 classifiers = ['Development Status :: 5 - Production/Stable',
                'Operating System :: POSIX :: Linux',
                'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
@@ -14,7 +24,7 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Topic :: System :: Hardware :: Hardware Drivers']
 
 setup(	name		= "spidev",
-	version		= "3.2",
+	version		= version,
 	description	= "Python bindings for Linux SPI access through spidev",
 	long_description= open('README.md').read() + "\n" + open('CHANGELOG.md').read(),
 	author		= "Volker Thoms",

--- a/spidev_module.c
+++ b/spidev_module.c
@@ -57,7 +57,7 @@ PyDoc_STRVAR(SpiDev_module_doc,
 typedef struct {
 	PyObject_HEAD
 
-	int fd;	/* open file descriptor: /dev/spi-X.Y */
+	int fd;	/* open file descriptor: /dev/spidevX.Y */
 	uint8_t mode;	/* current SPI mode */
 	uint8_t bits_per_word;	/* current SPI bits per word setting */
 	uint32_t max_speed_hz;	/* current SPI max speed setting in Hz */
@@ -889,7 +889,7 @@ static PyGetSetDef SpiDev_getset[] = {
 PyDoc_STRVAR(SpiDev_open_doc,
 	"open(bus, device)\n\n"
 	"Connects the object to the specified SPI device.\n"
-	"open(X,Y) will open /dev/spidev-X.Y\n");
+	"open(X,Y) will open /dev/spidev<X>.<Y>\n");
 
 static PyObject *
 SpiDev_open(SpiDevObject *self, PyObject *args, PyObject *kwds)

--- a/spidev_module.c
+++ b/spidev_module.c
@@ -27,6 +27,7 @@
 #include <sys/ioctl.h>
 #include <linux/ioctl.h>
 
+#define _VERSION_ "3.3"
 #define SPIDEV_MAXPATH 4096
 
 
@@ -1089,9 +1090,16 @@ void initspidev(void)
 
 #if PY_MAJOR_VERSION >= 3
 	m = PyModule_Create(&moduledef);
+	PyObject *version = PyUnicode_FromString(_VERSION_);
 #else
 	m = Py_InitModule3("spidev", SpiDev_module_methods, SpiDev_module_doc);
+	PyObject *version = PyString_FromString(_VERSION_);
 #endif
+
+	PyObject *dict = PyModule_GetDict(m);
+	PyDict_SetItemString(dict, "__version__", version);
+	Py_DECREF(version);
+
 	Py_INCREF(&SpiDevObjectType);
 	PyModule_AddObject(m, "SpiDev", (PyObject *)&SpiDevObjectType);
 


### PR DESCRIPTION
This PR adds the `__version__` attribute to the spidev module.

The version is defined at the top of `spidev_module.c`.

I have modified `setup.py` to read this version declaration, instead of defining it manually again. I'm not 100% sure this is worthwhile, but it's included in this PR for you to yay or nay as you see fit.