### PR TITLE
Suggetion on fix for generators in Python 3

### DIFF
--- a/spidev_module.c
+++ b/spidev_module.c
@@ -131,7 +131,7 @@ SpiDev_writebytes(SpiDevObject *self, PyObject *args)
 		return NULL;
 
 	seq = PySequence_Fast(obj, "expected a sequence");
-	len = PySequence_Fast_GET_SIZE(obj);
+	len = PySequence_Fast_GET_SIZE(seq);
 	if (!seq || len <= 0) {
 		PyErr_SetString(PyExc_TypeError, wrmsg_list0);
 		return NULL;


### PR DESCRIPTION
Had the following code:

__spi.writebytes(map(lambda rgb: __gamma[rgb], __rgb_leds))

Which worked in Python2 but gave a IO exeption in Python3 because map returns an iterator/gererator but not a list in this case. spidev complained that max bytes was exceeded. Maybe it checked the length of the generator code.

With the suggested code it might check the length of a list (I'm not a C++ dev)