### PR TITLE
MIT license in setup.py and update MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include spidev_module.c
 include README.md
 include CHANGELOG.md
-include LICENSE.md
+include LICENSE
 include setup.py

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ else:
 
 classifiers = ['Development Status :: 5 - Production/Stable',
                'Operating System :: POSIX :: Linux',
-               'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
+               'License :: OSI Approved :: MIT License',
                'Intended Audience :: Developers',
                'Programming Language :: Python :: 2.6',
                'Programming Language :: Python :: 2.7',
@@ -31,7 +31,7 @@ setup(	name		= "spidev",
 	author_email	= "unconnected@gmx.de",
 	maintainer	= "Stephen Caudle",
 	maintainer_email= "scaudle@doceme.com",
-	license		= "GPLv2",
+	license		= "MIT",
 	classifiers	= classifiers,
 	url		= "http://github.com/doceme/py-spidev",
 	ext_modules	= [Extension("spidev", ["spidev_module.c"])]


### PR DESCRIPTION
mainifest was still looking for LICENSE.md, but the file name was change in the move to MIT

Fixes #89