### PR TITLE
Call Py_DECREF to fix leaked reference counts, should fix #91

### DIFF
--- a/spidev_module.c
+++ b/spidev_module.c
@@ -268,7 +268,7 @@ SpiDev_readbytes(SpiDevObject *self, PyObject *args)
 
 	for (ii = 0; ii < len; ii++) {
 		PyObject *val = Py_BuildValue("l", (long)rxbuf[ii]);
-		PyList_SET_ITEM(list, ii, val);
+		PyList_SET_ITEM(list, ii, val);  // Steals reference, no need to Py_DECREF(val)
 	}
 
 	return list;
@@ -588,6 +588,7 @@ SpiDev_xfer(SpiDevObject *self, PyObject *args)
 	for (ii = 0; ii < len; ii++) {
 		PyObject *val = Py_BuildValue("l", (long)rxbuf[ii]);
 		PySequence_SetItem(seq, ii, val);
+		Py_DECREF(val); // PySequence_SetItem does not steal reference, must Py_DECREF(val)
 	}
 
 	// WA:
@@ -698,6 +699,7 @@ SpiDev_xfer2(SpiDevObject *self, PyObject *args)
 	for (ii = 0; ii < len; ii++) {
 		PyObject *val = Py_BuildValue("l", (long)rxbuf[ii]);
 		PySequence_SetItem(seq, ii, val);
+		Py_DECREF(val); // PySequence_SetItem does not steal reference, must Py_DECREF(val)
 	}
 	// WA:
 	// in CS_HIGH mode CS isnt pulled to low after transfer
@@ -845,7 +847,7 @@ SpiDev_xfer3(SpiDevObject *self, PyObject *args)
 		}
 		for (ii = 0, jj = block_start; ii < block_size; ii++, jj++) {
 			PyObject *val = Py_BuildValue("l", (long)rxbuf[ii]);
-			PyTuple_SetItem(rx_tuple, jj, val);
+			PyTuple_SetItem(rx_tuple, jj, val);  // Steals reference, no need to Py_DECREF(val)
 		}
 
 		block_start += block_size;

--- a/spidev_module.c
+++ b/spidev_module.c
@@ -267,7 +267,7 @@ SpiDev_readbytes(SpiDevObject *self, PyObject *args)
 	list = PyList_New(len);
 
 	for (ii = 0; ii < len; ii++) {
-		PyObject *val = Py_BuildValue("l", (long)rxbuf[ii]);
+		PyObject *val = PyLong_FromLong((long)rxbuf[ii]);
 		PyList_SET_ITEM(list, ii, val);  // Steals reference, no need to Py_DECREF(val)
 	}
 
@@ -586,7 +586,7 @@ SpiDev_xfer(SpiDevObject *self, PyObject *args)
 #endif
 
 	for (ii = 0; ii < len; ii++) {
-		PyObject *val = Py_BuildValue("l", (long)rxbuf[ii]);
+		PyObject *val = PyLong_FromLong((long)rxbuf[ii]);
 		PySequence_SetItem(seq, ii, val);
 		Py_DECREF(val); // PySequence_SetItem does not steal reference, must Py_DECREF(val)
 	}
@@ -697,7 +697,7 @@ SpiDev_xfer2(SpiDevObject *self, PyObject *args)
 	}
 
 	for (ii = 0; ii < len; ii++) {
-		PyObject *val = Py_BuildValue("l", (long)rxbuf[ii]);
+		PyObject *val = PyLong_FromLong((long)rxbuf[ii]);
 		PySequence_SetItem(seq, ii, val);
 		Py_DECREF(val); // PySequence_SetItem does not steal reference, must Py_DECREF(val)
 	}
@@ -846,7 +846,7 @@ SpiDev_xfer3(SpiDevObject *self, PyObject *args)
 			return NULL;
 		}
 		for (ii = 0, jj = block_start; ii < block_size; ii++, jj++) {
-			PyObject *val = Py_BuildValue("l", (long)rxbuf[ii]);
+			PyObject *val = PyLong_FromLong((long)rxbuf[ii]);
 			PyTuple_SetItem(rx_tuple, jj, val);  // Steals reference, no need to Py_DECREF(val)
 		}
 


### PR DESCRIPTION
I finally traced #91 back to a missing `Py_DECREF` after `PySequence_SetItem`. Unlike, for example, `PyList_SET_ITEM`, this function is *not* reference stealing.

I've added some comments that attempt to clarify the difference between the way this code handles reference stealing and non-reference stealing calls.

Coming along for the ride in this fix is a swap from `Py_BuildValue` to `PyLong_FromLong`, which avoids the need for a format string and should- in theory- be faster. This isn't entirely unrelated, since it aims to balance the cost of calling `Py_DECREF` for every byte, but I have no substantive evidence to back this up.

```python
import spidev
import time

bus = spidev.SpiDev(0, 0)

bus.mode = 0
bus.lsbfirst = False
bus.max_speed_hz = 80 * 1000000

bytes_total = 0
transfers_total = 0
last_update = time.time()
time_start = last_update

while True:
    bus.xfer([0b10101010] * 4096)
    bytes_total += 4096
    transfers_total += 1
    if time.time() - last_update >= 60.0:
        print(f"{time.time() - time_start:.2f} - {bytes_total:,}b {transfers_total:,}")
        last_update = time.time()
```