### PR TITLE
Update to setuptools, fix pypi formatting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 version = "0.0"
 
@@ -27,6 +27,7 @@ setup(	name		= "spidev",
 	version		= version,
 	description	= "Python bindings for Linux SPI access through spidev",
 	long_description= open('README.md').read() + "\n" + open('CHANGELOG.md').read(),
+        long_description_content_type = "text/markdown",
 	author		= "Volker Thoms",
 	author_email	= "unconnected@gmx.de",
 	maintainer	= "Stephen Caudle",


### PR DESCRIPTION
I'm anticipating a release to include the recent stability fixes, and figured I'd get some QOL improvements in quickly.

This change makes a couple of - hopefully minor since I don't know what the process for shipping this library as a Raspbian .deb is - tweaks to `setup.py`.

Specifically I have replaced the deprecated `distutils.core` with `setuptools` since this permits commands like `devel` which are super useful for development and testing.

Additionally I have added the `long_description_content_type` field, which fixes the formatting of the markdown README on PyPi. See this test upload: https://test.pypi.org/project/spidev-test/

Contrast to the page without this fix: https://test.pypi.org/project/spidev/