### PR TITLE
Set IOError in __spidev_set_mode if readback differs

### DIFF
--- a/spidev_module.c
+++ b/spidev_module.c
@@ -902,6 +902,9 @@ static int __spidev_set_mode( int fd, __u8 mode) {
 		return -1;
 	}
 	if (test != mode) {
+		PyErr_Format(PyExc_IOError,
+			"Attempted to set mode 0x%x but mode 0x%x returned",
+			(unsigned int)mode, (unsigned int)test);
 		return -1;
 	}
 	return 0;


### PR DESCRIPTION
Apparently on Raspberry Pi (model A) with `spi_bcm2835` (5.4.51+),  `CS_HIGH` (`0x04`)  is always set.

Consider this test code:
```python
#!/usr/bin/env python3
import spidev

spi = spidev.SpiDev()
spi.open(0, 0)

spi.cshigh = False
```

Previously, it would crash with the following trace:
```
Traceback (most recent call last):
  File "./test.py", line 7, in <module>
    spi.cshigh = False
SystemError: error return without exception set
```

It now raises an `IOError` (`OSError`) which explains exactly what happened:
```
Traceback (most recent call last):
  File "ds3234/test.py", line 7, in <module>
    spi.cshigh = False
OSError: Attempted to set mode 0x1 but mode 0x5 returned
```


This fixes #108