### PR TITLE
spidev_module: fix writebytes segfault

### DIFF
--- a/spidev_module.c
+++ b/spidev_module.c
@@ -184,8 +184,11 @@ SpiDev_writebytes(SpiDevObject *self, PyObject *args)
 		return NULL;
 
 	seq = PySequence_Fast(obj, "expected a sequence");
+	if (!seq)
+		return NULL;
+
 	len = PySequence_Fast_GET_SIZE(seq);
-	if (!seq || len <= 0) {
+	if (len <= 0) {
 		PyErr_SetString(PyExc_TypeError, wrmsg_list0);
 		return NULL;
 	}


### PR DESCRIPTION
If the argument to writebytes was not a sequence, it would segfault because `seq` was being operated on without first checking for error.