### PR TITLE
Support 32-bit mode flags and SPI_MOSI_IDLE_LOW

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ spi.open_path(spidev_devicefile_path)
 to_send = [0x01, 0x02, 0x03]
 spi.xfer(to_send)
 ```
+
+## Kernel
+
+The module uses the `SPI_IOC_RD_MODE32` and `SPI_IOC_WR_MODE32` ioctls that are
+available since Linux kernel version 3.15. Older kernels are not supported.
+
+Some features (e.g. `mosi_idle_low`) depend on the support being available in
+the Linux kernel. Make sure the module is built against the proper kernel
+header versions, otherwise the feature might be missing.
+
 ## Settings
 
 ```python

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ spi.mode = 0b01
   min: 0b00 = 0, max: 0b11 = 3
 * `threewire` - SI/SO signals shared
 * `read0` - Read 0 bytes after transfer to lower CS if cshigh == True
+* `mosi_idle_low` - Set SO line to low when idle
 
 > [!IMPORTANT]
 > To be able to use a setting attribute, it needs to be supported by the

--- a/spidev_module.c
+++ b/spidev_module.c
@@ -1311,6 +1311,52 @@ SpiDev_set_read0(SpiDevObject *self, PyObject *val, void *closure)
 	return 0;
 }
 
+#ifdef SPI_MOSI_IDLE_LOW
+
+static PyObject *
+SpiDev_get_mosi_idle_low(SpiDevObject *self, void *closure)
+{
+	PyObject *result;
+
+	if (self->mode & SPI_MOSI_IDLE_LOW)
+		result = Py_True;
+	else
+		result = Py_False;
+
+	Py_INCREF(result);
+	return result;
+}
+
+static int
+SpiDev_set_mosi_idle_low(SpiDevObject *self, PyObject *val, void *closure)
+{
+	uint32_t tmp;
+	int ret;
+
+	if (val == NULL) {
+		PyErr_SetString(PyExc_TypeError,
+			"Cannot delete attribute");
+		return -1;
+	}
+	else if (!PyBool_Check(val)) {
+		PyErr_SetString(PyExc_TypeError,
+			"The mosi_idle_low attribute must be boolean");
+		return -1;
+	}
+
+	if (val == Py_True)
+		tmp = self->mode | SPI_MOSI_IDLE_LOW;
+	else
+		tmp = self->mode & ~SPI_MOSI_IDLE_LOW;
+
+	ret = __spidev_set_mode(self->fd, tmp);
+
+	if (ret != -1)
+		self->mode = tmp;
+	return ret;
+}
+#endif /* SPI_MOSI_IDLE_LOW */
+
 static PyGetSetDef SpiDev_getset[] = {
 	{"mode", (getter)SpiDev_get_mode, (setter)SpiDev_set_mode,
 			"SPI mode as two bit pattern of \n"
@@ -1332,6 +1378,10 @@ static PyGetSetDef SpiDev_getset[] = {
 			"maximum speed in Hz\n"},
 	{"read0", (getter)SpiDev_get_read0, (setter)SpiDev_set_read0,
 			"Read 0 bytes after transfer to lower CS if cshigh == True\n"},
+#ifdef SPI_MOSI_IDLE_LOW
+	{"mosi_idle_low", (getter)SpiDev_get_mosi_idle_low, (setter)SpiDev_set_mosi_idle_low,
+			"mosi line low when idle\n"},
+#endif
 	{NULL},
 };
 

--- a/spidev_module.c
+++ b/spidev_module.c
@@ -108,7 +108,7 @@ typedef struct {
 	PyObject_HEAD
 
 	int fd;	/* open file descriptor: /dev/spidevX.Y */
-	uint8_t mode;	/* current SPI mode */
+	uint32_t mode;	/* current SPI mode */
 	uint8_t bits_per_word;	/* current SPI bits per word setting */
 	uint32_t max_speed_hz;	/* current SPI max speed setting in Hz */
 	uint8_t read0;	/* read 0 bytes after transfer to lwoer CS if SPI_CS_HIGH */
@@ -891,13 +891,13 @@ SpiDev_xfer3(SpiDevObject *self, PyObject *args)
 	return rx_tuple;
 }
 
-static int __spidev_set_mode( int fd, __u8 mode) {
-	__u8 test;
-	if (ioctl(fd, SPI_IOC_WR_MODE, &mode) == -1) {
+static int __spidev_set_mode( int fd, __u32 mode) {
+	__u32 test;
+	if (ioctl(fd, SPI_IOC_WR_MODE32, &mode) == -1) {
 		PyErr_SetFromErrno(PyExc_IOError);
 		return -1;
 	}
-	if (ioctl(fd, SPI_IOC_RD_MODE, &test) == -1) {
+	if (ioctl(fd, SPI_IOC_RD_MODE32, &test) == -1) {
 		PyErr_SetFromErrno(PyExc_IOError);
 		return -1;
 	}
@@ -1004,7 +1004,8 @@ SpiDev_get_no_cs(SpiDevObject *self, void *closure)
 static int
 SpiDev_set_mode(SpiDevObject *self, PyObject *val, void *closure)
 {
-	uint8_t mode, tmp;
+	uint8_t mode;
+	uint32_t tmp;
 	int ret;
 
 	if (val == NULL) {
@@ -1048,7 +1049,7 @@ SpiDev_set_mode(SpiDevObject *self, PyObject *val, void *closure)
 static int
 SpiDev_set_cshigh(SpiDevObject *self, PyObject *val, void *closure)
 {
-	uint8_t tmp;
+	uint32_t tmp;
 	int ret;
 
 	if (val == NULL) {
@@ -1077,7 +1078,7 @@ SpiDev_set_cshigh(SpiDevObject *self, PyObject *val, void *closure)
 static int
 SpiDev_set_lsbfirst(SpiDevObject *self, PyObject *val, void *closure)
 {
-	uint8_t tmp;
+	uint32_t tmp;
 	int ret;
 
 	if (val == NULL) {
@@ -1106,7 +1107,7 @@ SpiDev_set_lsbfirst(SpiDevObject *self, PyObject *val, void *closure)
 static int
 SpiDev_set_3wire(SpiDevObject *self, PyObject *val, void *closure)
 {
-	uint8_t tmp;
+	uint32_t tmp;
 	int ret;
 
 	if (val == NULL) {
@@ -1135,7 +1136,7 @@ SpiDev_set_3wire(SpiDevObject *self, PyObject *val, void *closure)
 static int
 SpiDev_set_no_cs(SpiDevObject *self, PyObject *val, void *closure)
 {
-        uint8_t tmp;
+        uint32_t tmp;
 	int ret;
 
         if (val == NULL) {
@@ -1165,7 +1166,7 @@ SpiDev_set_no_cs(SpiDevObject *self, PyObject *val, void *closure)
 static int
 SpiDev_set_loop(SpiDevObject *self, PyObject *val, void *closure)
 {
-	uint8_t tmp;
+	uint32_t tmp;
 	int ret;
 
 	if (val == NULL) {
@@ -1343,11 +1344,11 @@ SpiDev_open_dev(SpiDevObject *self, char *dev_path)
 		PyErr_SetFromErrno(PyExc_IOError);
 		return NULL;
 	}
-	if (ioctl(self->fd, SPI_IOC_RD_MODE, &tmp8) == -1) {
+	if (ioctl(self->fd, SPI_IOC_RD_MODE32, &tmp32) == -1) {
 		PyErr_SetFromErrno(PyExc_IOError);
 		return NULL;
 	}
-	self->mode = tmp8;
+	self->mode = tmp32;
 	if (ioctl(self->fd, SPI_IOC_RD_BITS_PER_WORD, &tmp8) == -1) {
 		PyErr_SetFromErrno(PyExc_IOError);
 		return NULL;


### PR DESCRIPTION
In Linux 3.15 (11 years ago) the size of the mode field was increased from 8 to 32 bits. In order to support some of the newer mode flags like `SPI_MOSI_IDLE_LOW`, let's switch to use the new ioctls and store a 32 bit value in SpiDevObject.

This breaks the compatibility with Linux kernel versions before v3.15.

The support for the `mosi_idle_low` attribute is wrapped in `#ifdef SPI_MOSI_IDLE_LOW` to make sure the module still compiles when using kernel header versions before v6.5 where support for `SPI_MOSI_IDLE_LOW` was added.

This solves https://github.com/doceme/py-spidev/issues/136.