### PR TITLE
ci: run ruff linter for PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Ruff Check
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run ruff check
+        uses: astral-sh/ruff-action@v3
+
+      - name: Check formatting
+        run: ruff format --check --diff

--- a/.github/workflows/md-line-length.yml
+++ b/.github/workflows/md-line-length.yml
@@ -1,0 +1,19 @@
+name: Check Markdown Line Length
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+
+jobs:
+  check-line-length:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Check line length in Markdown files
+        run: |
+          files=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- '*.md')
+          grep -n '.\\{80,\\}' $files && exit 1 || exit 0


### PR DESCRIPTION
I think this works. It runs [Astral's](https://astral.sh) Ruff to lint (`ruff check`) the code and check formatting (`ruff format --check --diff`). If the diff output would be too verbose, the argument can be removed from the command.

Having CI enables us to keep a consistent coding style for the Python files and catch simple bugs early.

I've also included the pre-commit check for the contributors that do not have pre-commit installed.