### PR TITLE
pyproject.toml for packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include spidev_module.c
-include README.md
-include CHANGELOG.md
-include LICENSE
-include setup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,41 @@
+[project]
+name = "spidev"
+description = "Python bindings for Linux SPI access through spidev"
+dynamic = ["version", "readme"]
+
+authors = [
+    { name = "Volker Thoms", email = "unconnected@gmx.de" },
+]
+maintainers = [
+    { name = "Stephen Caudle", email = "scaudle@doceme.com" },
+]
+license = "MIT"
+license-files = ["LICENSE"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Operating System :: POSIX :: Linux",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development",
+    "Topic :: System :: Hardware",
+    "Topic :: System :: Hardware :: Hardware Drivers",
+]
+keywords = ["SPI", "Linux", "SPI device"]
+requires-python = ">=3.8"
+
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=80.0"]
 build-backend = "setuptools.build_meta"
+
+[project.urls]
+Repository = "http://github.com/doceme/py-spidev"
+Issues = "https://github.com/doceme/py-spidev/issues"
+Changelog = "https://github.com/doceme/py-spidev/blob/master/CHANGELOG.md"
+
+[tool.setuptools]
+ext-modules = [
+  {name = "spidev", sources = ["spidev_module.c"]}
+]
+
+[tool.setuptools.dynamic]
+readme = {file = ["README.md"], content-type = "text/markdown" }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup, Extension
+from setuptools import setup
 
 version = "0.0"
 
@@ -11,29 +11,6 @@ if len(lines) > 0:
 else:
     raise Exception("Unable to find _VERSION_ in spidev_module.c")
 
-
-classifiers = ['Development Status :: 5 - Production/Stable',
-               'Operating System :: POSIX :: Linux',
-               'License :: OSI Approved :: MIT License',
-               'Intended Audience :: Developers',
-               'Programming Language :: Python :: 2.6',
-               'Programming Language :: Python :: 2.7',
-               'Programming Language :: Python :: 3',
-               'Topic :: Software Development',
-               'Topic :: System :: Hardware',
-               'Topic :: System :: Hardware :: Hardware Drivers']
-
-setup(	name		= "spidev",
-	version		= version,
-	description	= "Python bindings for Linux SPI access through spidev",
-	long_description= open('README.md').read() + "\n" + open('CHANGELOG.md').read(),
-        long_description_content_type = "text/markdown",
-	author		= "Volker Thoms",
-	author_email	= "unconnected@gmx.de",
-	maintainer	= "Stephen Caudle",
-	maintainer_email= "scaudle@doceme.com",
-	license		= "MIT",
-	classifiers	= classifiers,
-	url		= "http://github.com/doceme/py-spidev",
-	ext_modules	= [Extension("spidev", ["spidev_module.c"])]
+setup(
+    version = version,
 )


### PR DESCRIPTION
I'm not entirely sure if support for setup.py can be dropped, but I leave that up to the maintainers. This can replace the following files:

MANIFEST.in
setup.py
setup.cfg